### PR TITLE
fix: remove hardcoded API_PORT from Dockerfile for Railway compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,16 +54,15 @@ RUN mkdir -p /app/data
 # Copy the compiled binary from builder
 COPY --from=builder /app/target/release/trader-tony-v4 /app/trader-tony-v4
 
-# Expose the API port (Railway will set PORT env var)
-EXPOSE 3030
-
 # Note: Railway uses its own health check (healthcheckPath in railway.toml)
 # Docker HEALTHCHECK removed as it requires curl which isn't in slim image
 
 # Default environment variables
 ENV RUST_LOG=info
 ENV API_HOST=0.0.0.0
-ENV API_PORT=3030
+# DO NOT set API_PORT here - Railway sets PORT dynamically and our config
+# falls back to PORT when API_PORT is not set. Setting API_PORT here would
+# override Railway's port assignment and cause healthcheck failures.
 
 # Run the application
 CMD ["./trader-tony-v4"]

--- a/railway.toml
+++ b/railway.toml
@@ -11,7 +11,7 @@ startCommand = "./trader-tony-v4"
 
 # Health check endpoint for Railway
 healthcheckPath = "/api/health"
-healthcheckTimeout = 60
+healthcheckTimeout = 120
 
 # Number of replicas (keep at 1 for trading bot to avoid duplicate trades)
 numReplicas = 1


### PR DESCRIPTION
The Dockerfile was setting API_PORT=3030 which overrode Railway's dynamically assigned PORT env var. Since our config reads API_PORT first, the app was always binding to 3030 while Railway expected it on PORT, causing healthcheck failures. Also increased healthcheck timeout to 120s.