### PR TITLE
fix: restore API_PORT=3030 in Dockerfile for Railway deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,7 @@ RUN mkdir src && \
 RUN cargo build --release && \
     rm -rf src target/release/trader-tony-v4*
 
-# Cache bust: any change to source files invalidates from here
-# Railway may aggressively cache COPY layers, so we use a build arg
-ARG CACHEBUST=1
+# Copy actual source code
 COPY src ./src
 
 # Build the actual application
@@ -56,15 +54,16 @@ RUN mkdir -p /app/data
 # Copy the compiled binary from builder
 COPY --from=builder /app/target/release/trader-tony-v4 /app/trader-tony-v4
 
+# Expose the API port (Railway routes to this port)
+EXPOSE 3030
+
 # Note: Railway uses its own health check (healthcheckPath in railway.toml)
 # Docker HEALTHCHECK removed as it requires curl which isn't in slim image
 
 # Default environment variables
 ENV RUST_LOG=info
 ENV API_HOST=0.0.0.0
-# DO NOT set API_PORT here - Railway sets PORT dynamically and our config
-# falls back to PORT when API_PORT is not set. Setting API_PORT here would
-# override Railway's port assignment and cause healthcheck failures.
+ENV API_PORT=3030
 
 # Run the application
 CMD ["./trader-tony-v4"]

--- a/railway.toml
+++ b/railway.toml
@@ -11,7 +11,7 @@ startCommand = "./trader-tony-v4"
 
 # Health check endpoint for Railway
 healthcheckPath = "/api/health"
-healthcheckTimeout = 120
+healthcheckTimeout = 60
 
 # Number of replicas (keep at 1 for trading bot to avoid duplicate trades)
 numReplicas = 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,9 @@ async fn main() -> Result<()> {
 
     // Load configuration
     let config = Arc::new(Config::load()?);
-    info!("Configuration loaded successfully");
+    info!("Configuration loaded successfully (v4.1.0 - multi-strategy)");
     info!("Demo mode: {}", config.demo_mode);
+    info!("Dry run mode: {}", config.dry_run_mode);
 
     // Initialize Solana client
     let solana_client = Arc::new(SolanaClient::new(&config.solana_rpc_url)?);


### PR DESCRIPTION
Railway is configured to route to port 3030. The previous working deployment used hardcoded API_PORT=3030 (confirmed from git history - the dynamic PORT approach was tried Jan 15 and reverted). Restoring the working configuration. Added version info to startup logging.