### PR TITLE
fix: wire strategy type dropdown change event to API call

### DIFF
--- a/webapp/js/app.js
+++ b/webapp/js/app.js
@@ -661,6 +661,12 @@ const App = {
             stopBtn.addEventListener('click', () => this.stopTrading());
         }
 
+        // Strategy type selector
+        const strategySelect = document.getElementById('strategyTypeSelect');
+        if (strategySelect) {
+            strategySelect.addEventListener('change', (e) => this.setActiveStrategyType(e.target.value));
+        }
+
         // Analyze token button
         const analyzeBtn = document.getElementById('analyzeTokenBtn');
         if (analyzeBtn) {


### PR DESCRIPTION
The strategy selector dropdown had no event listener - selecting FinalStretch or Migrated had no effect because the change was never sent to the backend. Added change event listener on strategyTypeSelect to call setActiveStrategyType() API.