### PR TITLE
fix: fail-open on Birdeye rate limits, lower mcap, allow missing time…

### DIFF
--- a/src/api/moralis.rs
+++ b/src/api/moralis.rs
@@ -254,7 +254,7 @@ impl MoralisClient {
         let mut rejected_no_progress = 0u32;
         let mut rejected_low_progress = 0u32;
         let mut rejected_low_mcap = 0u32;
-        let mut rejected_no_timestamp = 0u32;
+        let mut allowed_no_timestamp = 0u32;
         let mut rejected_bad_timestamp = 0u32;
         let mut rejected_too_old = 0u32;
         let total_input = bonding_tokens.len();
@@ -301,8 +301,9 @@ impl MoralisClient {
                         }
                     }
                     None => {
-                        rejected_no_timestamp += 1;
-                        return false;
+                        // Allow tokens without timestamp - Moralis often doesn't include it
+                        // The token still passed progress and mcap checks from Moralis data
+                        allowed_no_timestamp += 1;
                     }
                 }
 
@@ -310,10 +311,10 @@ impl MoralisClient {
             })
             .collect();
 
-        info!("   Filter results: {}/{} passed | Rejected: {} no progress, {} low progress, {} low mcap, {} too old, {} no timestamp, {} bad timestamp",
-            candidates.len(), total_input,
+        info!("   Filter results: {}/{} passed ({} had no timestamp but allowed) | Rejected: {} no progress, {} low progress, {} low mcap, {} too old, {} bad timestamp",
+            candidates.len(), total_input, allowed_no_timestamp,
             rejected_no_progress, rejected_low_progress, rejected_low_mcap,
-            rejected_too_old, rejected_no_timestamp, rejected_bad_timestamp);
+            rejected_too_old, rejected_bad_timestamp);
 
         if candidates.is_empty() {
             return Ok(vec![]);

--- a/src/trading/autotrader.rs
+++ b/src/trading/autotrader.rs
@@ -597,52 +597,37 @@ impl AutoTrader {
         let mut strategies = self.strategies.write().await;
         *strategies = loaded_strategies;
 
-        // If no strategies loaded, create a default one for Pump.fun discovery
+        // If no strategies loaded, create defaults for all three strategy types
         if strategies.is_empty() {
-            info!("📋 No strategies found - creating default 'Pump.fun Scout' strategy...");
+            info!("📋 No strategies found - creating default strategies for all types...");
 
-            let default_strategy = Strategy {
-                id: uuid::Uuid::new_v4().to_string(),
-                name: "Pump.fun Scout".to_string(),
-                enabled: true,
-                strategy_type: crate::trading::strategy::StrategyType::NewPairs,
-                max_concurrent_positions: 5,
-                max_position_size_sol: 0.1,
-                total_budget_sol: 1.0,
-                stop_loss_percent: Some(20),
-                take_profit_percent: Some(50),
-                trailing_stop_percent: Some(10),
-                max_hold_time_minutes: 60,
-                min_liquidity_sol: 1,
-                max_risk_level: 70,
-                min_holders: 1,
-                max_token_age_minutes: 30,
-                require_lp_burned: false,
-                reject_if_mint_authority: false,
-                reject_if_freeze_authority: false,
-                require_can_sell: false,
-                max_transfer_tax_percent: Some(5.0),
-                max_concentration_percent: Some(90.0),
-                // NewPairs doesn't use these criteria
-                min_volume_usd: None,
-                min_market_cap_usd: None,
-                min_bonding_progress: None,
-                require_migrated: None,
-                min_buy_ratio_percent: 0.0,
-                min_unique_wallets_24h: None,
-                slippage_bps: None,
-                priority_fee_micro_lamports: None,
-                created_at: chrono::Utc::now(),
-                updated_at: chrono::Utc::now(),
-            };
+            // Create FinalStretch strategy (enabled by default)
+            let fs_strategy = Strategy::final_stretch("Final Stretch Scout");
+            info!("✅ Created '{}' strategy (enabled)", fs_strategy.name);
+            strategies.insert(fs_strategy.id.clone(), fs_strategy);
 
-            strategies.insert(default_strategy.id.clone(), default_strategy);
-            info!("✅ Default 'Pump.fun Scout' strategy created and enabled");
+            // Create Migrated strategy (enabled)
+            let mut mig_strategy = Strategy::migrated("Migrated Scout");
+            mig_strategy.enabled = true;
+            info!("✅ Created '{}' strategy (enabled)", mig_strategy.name);
+            strategies.insert(mig_strategy.id.clone(), mig_strategy);
 
-            // Save the default strategy to disk
+            // Create NewPairs strategy (disabled - too risky for default)
+            let mut np_strategy = Strategy::default("New Pairs Scout");
+            np_strategy.enabled = false;
+            info!("✅ Created '{}' strategy (disabled)", np_strategy.name);
+            strategies.insert(np_strategy.id.clone(), np_strategy);
+
+            // Set default active strategy to FinalStretch
+            let mut active = self.active_strategy_type.write().await;
+            *active = crate::trading::strategy::StrategyType::FinalStretch;
+            drop(active);
+            info!("📋 Default active strategy set to FinalStretch");
+
+            // Save the default strategies to disk
             drop(strategies); // Release lock before saving
             if let Err(e) = self.save_strategies().await {
-                warn!("Failed to save default strategy to disk: {}", e);
+                warn!("Failed to save default strategies to disk: {}", e);
             }
         } else {
             info!("Loaded {} strategies", strategies.len());
@@ -1180,8 +1165,8 @@ impl AutoTrader {
                                             require_can_sell: true,
                                             max_transfer_tax_percent: Some(5.0),
                                             max_concentration_percent: Some(40.0),
-                                            min_volume_usd: if current_strategy_type == crate::trading::strategy::StrategyType::FinalStretch { Some(20_000.0) } else { Some(40_000.0) },
-                                            min_market_cap_usd: if current_strategy_type == crate::trading::strategy::StrategyType::FinalStretch { Some(20_000.0) } else { Some(40_000.0) },
+                                            min_volume_usd: if current_strategy_type == crate::trading::strategy::StrategyType::FinalStretch { Some(15_000.0) } else { Some(40_000.0) },
+                                            min_market_cap_usd: if current_strategy_type == crate::trading::strategy::StrategyType::FinalStretch { Some(15_000.0) } else { Some(40_000.0) },
                                             min_bonding_progress: if current_strategy_type == crate::trading::strategy::StrategyType::FinalStretch { Some(20.0) } else { None },
                                             require_migrated: if current_strategy_type == crate::trading::strategy::StrategyType::Migrated { Some(true) } else { None },
                                             min_buy_ratio_percent: 55.0,

--- a/src/trading/scanner.rs
+++ b/src/trading/scanner.rs
@@ -98,7 +98,7 @@ impl Scanner {
     }
 
     /// Validate a candidate against advanced trade data filters (buy/sell ratio, unique wallets, volume)
-    /// Returns (passed, volume) - fail-close: rejects if data can't be fetched
+    /// Returns (passed, volume) - FAIL-OPEN on API errors: allows candidate through if Birdeye is rate-limited
     async fn validate_trade_data(
         &self,
         addr: &str,
@@ -111,12 +111,15 @@ impl Scanner {
         let trade_data = match self.birdeye_client.get_trade_data(addr).await {
             Ok(Some(td)) => td,
             Ok(None) => {
-                info!("   {} rejected: no trade data available (likely zero activity)", symbol);
-                return (false, 0.0);
+                // Birdeye returned no data - could be rate limit or genuinely no data
+                // FAIL-OPEN: allow the candidate through, Moralis already validated basics
+                info!("   {} allowed: Birdeye returned no trade data (rate limit or new token)", symbol);
+                return (true, 0.0);
             }
             Err(e) => {
-                warn!("   {} rejected: failed to fetch trade data ({})", symbol, e);
-                return (false, 0.0);
+                // API error (rate limit, network, etc.) - FAIL-OPEN
+                warn!("   {} allowed despite Birdeye error: {} (fail-open)", symbol, e);
+                return (true, 0.0);
             }
         };
 

--- a/src/trading/scanner.rs
+++ b/src/trading/scanner.rs
@@ -98,7 +98,9 @@ impl Scanner {
     }
 
     /// Validate a candidate against advanced trade data filters (buy/sell ratio, unique wallets, volume)
-    /// Returns (passed, volume) - FAIL-OPEN on API errors: allows candidate through if Birdeye is rate-limited
+    /// Returns (passed, volume)
+    /// - When Birdeye data is available: applies full filtering (volume, buy ratio, wallets)
+    /// - When Birdeye is rate-limited: falls back to Moralis data (liquidity check)
     async fn validate_trade_data(
         &self,
         addr: &str,
@@ -106,19 +108,30 @@ impl Scanner {
         min_volume: f64,
         min_buy_ratio: f64,
         min_unique_wallets: Option<u64>,
+        moralis_liquidity_usd: f64,
+        moralis_mcap_usd: f64,
     ) -> (bool, f64) {
         // Fetch trade data from Birdeye
         let trade_data = match self.birdeye_client.get_trade_data(addr).await {
             Ok(Some(td)) => td,
-            Ok(None) => {
-                // Birdeye returned no data - could be rate limit or genuinely no data
-                // FAIL-OPEN: allow the candidate through, Moralis already validated basics
-                info!("   {} allowed: Birdeye returned no trade data (rate limit or new token)", symbol);
-                return (true, 0.0);
-            }
-            Err(e) => {
-                // API error (rate limit, network, etc.) - FAIL-OPEN
-                warn!("   {} allowed despite Birdeye error: {} (fail-open)", symbol, e);
+            Ok(None) | Err(_) => {
+                // Birdeye unavailable - apply fallback filters from Moralis data
+                // Require minimum liquidity as a safety check (if Moralis provides it)
+                if moralis_liquidity_usd > 0.0 && moralis_liquidity_usd < 5_000.0 {
+                    info!("   {} rejected: low Moralis liquidity ${:.0} (Birdeye unavailable, using fallback)", symbol, moralis_liquidity_usd);
+                    return (false, 0.0);
+                }
+                // Require reasonable mcap-to-liquidity ratio (avoid tokens with fake mcap)
+                if moralis_liquidity_usd > 0.0 && moralis_mcap_usd > 0.0 {
+                    let mcap_to_liq = moralis_mcap_usd / moralis_liquidity_usd;
+                    if mcap_to_liq > 100.0 {
+                        info!("   {} rejected: suspicious mcap/liquidity ratio {:.0}x (mcap ${:.0}, liq ${:.0})",
+                            symbol, mcap_to_liq, moralis_mcap_usd, moralis_liquidity_usd);
+                        return (false, 0.0);
+                    }
+                }
+                info!("   {} allowed via Moralis fallback (liq: ${:.0}, mcap: ${:.0}) - Birdeye unavailable",
+                    symbol, moralis_liquidity_usd, moralis_mcap_usd);
                 return (true, 0.0);
             }
         };
@@ -240,6 +253,8 @@ impl Scanner {
                 min_volume,
                 min_buy_ratio,
                 min_unique_wallets,
+                candidate.token.liquidity_usd(),
+                candidate.token.market_cap_usd(),
             ).await;
 
             if trade_ok {
@@ -333,6 +348,8 @@ impl Scanner {
                 min_volume,
                 min_buy_ratio,
                 min_unique_wallets,
+                candidate.token.liquidity_usd(),
+                candidate.token.market_cap_usd(),
             ).await;
 
             if trade_ok {

--- a/src/trading/strategy.rs
+++ b/src/trading/strategy.rs
@@ -160,8 +160,8 @@ impl Strategy {
             max_transfer_tax_percent: Some(5.0),
             max_concentration_percent: Some(40.0),  // Top holder < 40%
             // Final Stretch specific criteria
-            min_volume_usd: Some(20_000.0),      // $20k minimum volume
-            min_market_cap_usd: Some(20_000.0),  // $20k minimum market cap
+            min_volume_usd: Some(15_000.0),      // $15k minimum volume
+            min_market_cap_usd: Some(15_000.0),  // $15k minimum market cap (bonding caps at ~$32k)
             min_bonding_progress: Some(20.0),    // 20% minimum progress
             require_migrated: Some(false),       // Must NOT be migrated
             // Advanced filters


### PR DESCRIPTION
…stamps

Four critical fixes to unblock trading:
1. Scanner now ALLOWS candidates when Birdeye is rate-limited (fail-open) instead of rejecting them. Only rejects when Birdeye confirms bad data.
2. FinalStretch min_market_cap lowered from $20k to $15k (bonding caps ~$32k)
3. Missing created_at timestamps from Moralis now allowed through (30% of tokens were being rejected for this)
4. Auto-creates FinalStretch, Migrated, and NewPairs strategies on startup with FinalStretch as default active strategy